### PR TITLE
Match inner blocks of a single passed block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
-Nothing yet.
+### Added
+
+- Passing a single block will return matches within its inner blocks.
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-- Passing a single block will return matches within its inner blocks.
+- Passing a single block instance will return matches within its inner blocks.
 
 ## 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Additionally:
 * The set of matching blocks can be limited by size (`limit`) or their position in the set of matches (`nth_of_type`).
 * The number of matches can be returned instead of the matched blocks (`count`).
 * The companion `match_block()` function reduces the filtered set of results to a single parsed block.
-* Passing a single block will return matches within its inner blocks.
+* Passing a single block instance will return matches from its inner blocks.
 
 `match_blocks()` is powered by a set of block validation classes that utilize the [Laminas Validator](https://docs.laminas.dev/laminas-validator/) framework and [Laminas Validator Extensions](https://github.com/alleyinteractive/laminas-validator-extensions) package. These validators, along with a base class for validating blocks, are included here. [See the validators section for their documentation](#validators).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Match Blocks
 
-`match_blocks()` selects the blocks in post content, or a given set of blocks or block HTML, that match the given criteria, such as the block name, block attributes, or position within the set of blocks.
+`match_blocks()` selects the blocks in post content, or in a given set of blocks, inner blocks, or block HTML, that match the given criteria, such as the block name, block attributes, or position within the set of blocks.
 
 Blocks can be matched by:
 
@@ -17,6 +17,7 @@ Additionally:
 * The set of matching blocks can be limited by size (`limit`) or their position in the set of matches (`nth_of_type`).
 * The number of matches can be returned instead of the matched blocks (`count`).
 * The companion `match_block()` function reduces the filtered set of results to a single parsed block.
+* Passing a single block will return matches within its inner blocks.
 
 `match_blocks()` is powered by a set of block validation classes that utilize the [Laminas Validator](https://docs.laminas.dev/laminas-validator/) framework and [Laminas Validator Extensions](https://github.com/alleyinteractive/laminas-validator-extensions) package. These validators, along with a base class for validating blocks, are included here. [See the validators section for their documentation](#validators).
 
@@ -66,13 +67,29 @@ $count = \Alley\WP\match_blocks(
 );
 ```
 
+Get the number of paragraph blocks that are inner blocks of the given group block:
+
+```php
+<?php
+
+$blocks = parse_blocks( '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph -->…<!-- wp:group /-->' );
+
+$count = \Alley\WP\match_blocks(
+    $blocks[0],
+    [
+        'count' => true,
+        'name'  => 'core/paragraph',
+    ]
+);
+```
+
 Get all paragraphs and headings:
 
 ```php
 <?php
 
 $blocks = \Alley\WP\match_blocks(
-    '<!-- wp:paragraph -->...',
+    '<!-- wp:paragraph -->…',
     [
         'name' => [ 'core/heading', 'core/paragraph' ],
     ]

--- a/src/alley/wp/match-blocks.php
+++ b/src/alley/wp/match-blocks.php
@@ -20,8 +20,10 @@ use Laminas\Validator\ValidatorChain;
 /**
  * Match blocks within the given content.
  *
- * @param array|int|\WP_Post|string $source Array of blocks, post ID or object with blocks in `post_content`, or string of block HTML.
- * @param array                     $args   {
+ * @param array[]|int|\WP_Post|string|\WP_Block_Parser_Block|array $source Array of blocks, post ID or object with blocks in `post_content`,
+ *                                                                         string of block HTML, or single parsed block. When a single block
+ *                                                                         is passed, its inner blocks will be matched.
+ * @param array                                                    $args   {
  *    Optional. Array of arguments for matching which blocks to return. The defaults serve to match all non-empty blocks.
  *
  *    @type array                     $attrs             {
@@ -81,6 +83,10 @@ function match_blocks( $source, $args = [] ) {
 	$blocks = [];
 	$error  = $args['count'] ? 0 : [];
 
+	if ( $source instanceof \WP_Block_Parser_Block ) {
+		$source = (array) $source;
+	}
+
 	if ( \is_array( $source ) ) {
 		$blocks = $source;
 	}
@@ -97,6 +103,10 @@ function match_blocks( $source, $args = [] ) {
 
 	if ( \is_string( $source ) ) {
 		$blocks = parse_blocks( $source );
+	}
+
+	if ( \is_array( $blocks ) && isset( $blocks['innerBlocks'] ) ) {
+		$blocks = $blocks['innerBlocks'];
 	}
 
 	if ( ! wp_is_numeric_array( $blocks ) || 0 === \count( $blocks ) ) {

--- a/src/alley/wp/match-blocks.php
+++ b/src/alley/wp/match-blocks.php
@@ -20,11 +20,11 @@ use Laminas\Validator\ValidatorChain;
 /**
  * Match blocks within the given content.
  *
- * @param array[]|int|\WP_Post|string|\WP_Block_Parser_Block|array $source Array of blocks, post ID or object with blocks in `post_content`,
- *                                                                         string of block HTML, or single parsed block. When a single block
- *                                                                         is passed, its inner blocks will be matched.
+ * @param int|\WP_Post|string|array[]|\WP_Block_Parser_Block|array $source Post ID or object with blocks in `post_content`, string of block HTML,
+ *                                                                         array of blocks, or a single block instance. Passing a single block
+ *                                                                         will return matches from its inner blocks.
  * @param array                                                    $args   {
- *    Optional. Array of arguments for matching which blocks to return. The defaults serve to match all non-empty blocks.
+ *    Optional. Array of arguments for matching which blocks to return. The defaults match all non-empty blocks.
  *
  *    @type array                     $attrs             {
  *        Match blocks with the given attributes.

--- a/src/alley/wp/match-blocks.php
+++ b/src/alley/wp/match-blocks.php
@@ -99,7 +99,7 @@ function match_blocks( $source, $args = [] ) {
 		$blocks = parse_blocks( $source );
 	}
 
-	if ( ! \is_array( $blocks ) || 0 === \count( $blocks ) ) {
+	if ( ! wp_is_numeric_array( $blocks ) || 0 === \count( $blocks ) ) {
 		return $error;
 	}
 

--- a/tests/alley/wp/test-match-blocks-source.php
+++ b/tests/alley/wp/test-match-blocks-source.php
@@ -30,7 +30,7 @@ final class Test_Match_Blocks_Source extends Test_Case {
 	}
 
 	/**
-	 * A single parsed block should match its inner blocks.
+	 * A single block instance should match its inner blocks.
 	 */
 	public function test_single_block_source() {
 		$html   = '<!-- wp:foo --><!-- wp:bar /--><!-- wp:baz /--><!-- wp:bat /--><!-- /wp:foo -->';

--- a/tests/alley/wp/test-match-blocks-source.php
+++ b/tests/alley/wp/test-match-blocks-source.php
@@ -30,6 +30,27 @@ final class Test_Match_Blocks_Source extends Test_Case {
 	}
 
 	/**
+	 * A single parsed block should match its inner blocks.
+	 */
+	public function test_single_block_source() {
+		$html   = '<!-- wp:foo --><!-- wp:bar /--><!-- wp:baz /--><!-- wp:bat /--><!-- /wp:foo -->';
+		$blocks = parse_blocks( $html );
+		$first  = array_shift( $blocks );
+
+		$this->assertCount( 3, match_blocks( $first ) );
+
+		$first = new \WP_Block_Parser_Block(
+			$first['blockName'],
+			$first['attrs'],
+			$first['innerBlocks'],
+			$first['innerHTML'],
+			$first['innerContent'],
+		);
+
+		$this->assertCount( 3, match_blocks( $first ) );
+	}
+
+	/**
 	 * Posts with no content should not return blocks.
 	 */
 	public function test_empty_source() {


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

- Passing a single block will return matches within its inner blocks.

### Changed

### Deprecated

### Removed

### Fixed

### Security
