### PR TITLE
Add 'with_innerhtml' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
+- `with_innerhtml` parameter for matching blocks by their inner HTML.
 - Passing a single block instance will return matches within its inner blocks.
 
 ## 1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-- `with_innerhtml` parameter for matching blocks by their inner HTML.
+- `with_innerhtml` parameter for matching blocks by their inner HTML. Includes companion `\Alley\WP\Validator\Block_InnerHTML` validator.
 - Passing a single block instance will return matches within its inner blocks.
 
 ## 1.0.1

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ $images = \Alley\WP\match_blocks(
 );
 ```
 
-Get only lists that contain list items:
+Get shortcode blocks with a specific shortcode:
 
 ```php
 <?php
@@ -203,8 +203,8 @@ Get only lists that contain list items:
 $blocks = \Alley\WP\match_blocks(
     $post,
     [
-        'name'           => 'core/list',
-        'with_innerhtml' => '<li',
+        'name'           => 'core/shortcode',
+        'with_innerhtml' => '[bc_video',
     ]
 );
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Blocks can be matched by:
 
 * Block name or names (`name`)
 * Block attributes (`attrs`, `with_attrs`)
+* Block inner HTML (`with_innerhtml`)
 * The block's positive or negative index within the set (`position`)
 * Whether the block represents only space (`skip_empty_blocks`)
 
@@ -174,7 +175,7 @@ Get all images credited to the Associated Press:
 ```php
 <?php
 
-$grafs = \Alley\WP\match_blocks(
+$images = \Alley\WP\match_blocks(
     $post,
     [
         'attrs' => [
@@ -190,6 +191,20 @@ $grafs = \Alley\WP\match_blocks(
             'relation' => 'OR',
         ],
         'name'  => 'core/image',
+    ]
+);
+```
+
+Get only lists that contain list items:
+
+```php
+<?php
+
+$blocks = \Alley\WP\match_blocks(
+    $post,
+    [
+        'name'           => 'core/list',
+        'with_innerhtml' => '<li',
     ]
 );
 ```
@@ -383,6 +398,49 @@ $valid = new Alley\WP\Validator\Block_Attribute(
         'key_operator' => 'REGEX',
         'value'        => [ 'audio', 'document' ],
         'operator'     => 'NOT IN',
+    ],
+);
+```
+### `Block_InnerHTML`
+
+`Alley\WP\Validator\Block_InnerHTML` validates whether the block contains, or does not contain, the specified content in its `innerHTML` property. The block passes if it contains an `innerHTML` value that matches the comparison.
+
+#### Supported options
+
+The following options are supported for `Alley\WP\Validator\Block_InnerHTML`:
+
+- `content`: The content to find or a regular expression pattern.
+- `operator`: The operator with which to compare `$content` to the block inner HTML. Accepts `CONTAINS`, `NOT CONTAINS`, `IN`, `NOT IN`, `LIKE`, `NOT LIKE`, `REGEX`, `NOT REGEX`, or any operator supported by `\Alley\Validator\Comparison` (see `\Alley\Validator\ValidatorByOperator`). Default is `LIKE`.
+
+#### Basic usage
+
+```php
+<?php
+
+// '
+// <!-- wp:paragraph -->
+// <p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable.</p>
+// <!-- /wp:paragraph -->
+// '
+
+$valid = new Alley\WP\Validator\Block_InnerHTML(
+    [
+        'content'  => 'wordpress',
+        'operator' => 'LIKE',
+    ],
+);
+
+$valid = new Alley\WP\Validator\Block_InnerHTML(
+    [
+        'content'  => 'WordPress',
+        'operator' => 'CONTAINS',
+    ],
+);
+
+$valid = new Alley\WP\Validator\Block_InnerHTML(
+    [
+        'content'  => '/^\s*<p>\s*</p>/',
+        'operator' => 'NOT REGEX',
     ],
 );
 ```

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "alleyinteractive/laminas-validator-extensions": "dev-fix/7-missed-messages"
+    "alleyinteractive/laminas-validator-extensions": "dev-main"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "lock": false
   },
   "require": {
-    "php": "^8.0",
-    "alleyinteractive/laminas-validator-extensions": "dev-feature/new-validators"
+    "php": "^7.4 || ^8.0",
+    "alleyinteractive/laminas-validator-extensions": "dev-fix/7-missed-messages"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "lock": false
   },
   "require": {
-    "php": "^7.4 || ^8.0",
-    "alleyinteractive/laminas-validator-extensions": "^1.1.0"
+    "php": "^8.0",
+    "alleyinteractive/laminas-validator-extensions": "dev-feature/new-validators"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3",

--- a/src/alley/wp/match-blocks.php
+++ b/src/alley/wp/match-blocks.php
@@ -12,6 +12,7 @@
 
 namespace Alley\WP;
 
+use Alley\WP\Validator\Block_InnerHTML;
 use Alley\WP\Validator\Block_Name;
 use Alley\WP\Validator\Block_Offset;
 use Alley\WP\Validator\Nonempty_Block;
@@ -61,6 +62,7 @@ use Laminas\Validator\ValidatorChain;
  *    @type bool                      $skip_empty_blocks Ignore blocks representing white space. Default true.
  *    @type string|string[]           $with_attrs        Match blocks with non-empty values for this attribute or these attributes.
  *                                                       Blocks must match all of the given `$with_attrs` and `$attrs`.
+ *    @type string                    $with_innerhtml    Match blocks whose `innerHTML` property contains this content, ignoring case.
  * }
  * @return array[]|int Array of found blocks or count thereof.
  */
@@ -77,6 +79,7 @@ function match_blocks( $source, $args = [] ) {
 			'position'          => null,
 			'skip_empty_blocks' => true,
 			'with_attrs'        => [],
+			'with_innerhtml'    => null,
 		],
 	);
 
@@ -167,6 +170,18 @@ function match_blocks( $source, $args = [] ) {
 		if ( $args['attrs'] && \is_array( $args['attrs'] ) ) {
 			$validator->attach(
 				Internals\parse_attrs_clauses( $args['attrs'] ),
+				true,
+			);
+		}
+
+		if ( \is_string( $args['with_innerhtml'] ) || $args['with_innerhtml'] instanceof \Stringable ) {
+			$validator->attach(
+				new Block_InnerHTML(
+					[
+						'content'  => $args['with_innerhtml'],
+						'operator' => 'LIKE',
+					],
+				),
 				true,
 			);
 		}

--- a/src/alley/wp/validator/class-block-innerhtml.php
+++ b/src/alley/wp/validator/class-block-innerhtml.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Block_InnerHTML class file
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-match-blocks
+ */
+
+namespace Alley\WP\Validator;
+
+use Alley\Validator\ValidatorByOperator;
+use Laminas\Validator\Exception\InvalidArgumentException;
+use Laminas\Validator\ValidatorInterface;
+use Traversable;
+use WP_Block;
+use WP_Block_Parser_Block;
+use WP_Error;
+
+/**
+ * Validates whether the given block's inner HTML contains the given content.
+ */
+final class Block_InnerHTML extends Block_Validator {
+	/**
+	 * Error code.
+	 *
+	 * @var string
+	 */
+	public const NO_MATCHING_INNERHTML = 'no_matching_innerhtml';
+
+	/**
+	 * Array of validation failure message templates.
+	 *
+	 * @var string[]
+	 */
+	protected $messageTemplates = [
+		self::NO_MATCHING_INNERHTML => '',
+	];
+
+	/**
+	 * Options for this validator.
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		'content'  => '',
+		'operator' => 'LIKE',
+	];
+
+	/**
+	 * Validates block inner HTML based on options.
+	 *
+	 * @var ValidatorInterface
+	 */
+	private ValidatorInterface $valid_html;
+
+	/**
+	 * Set up.
+	 *
+	 * @param array|Traversable $options Validator options.
+	 */
+	public function __construct( $options = null ) {
+		$this->messageTemplates[ self::NO_MATCHING_INNERHTML ] = __( 'Block inner HTML does not match.', 'alley' );
+
+		$this->valid_html = new ValidatorByOperator( $this->options['operator'], $this->options['content'] );
+
+		parent::__construct( $options );
+	}
+
+	/**
+	 * Sets one or multiple options. Merges new options into existing options, validates them in relation to one
+	 * another, and refreshes the cached validators for the comparisons.
+	 *
+	 * @throws InvalidArgumentException If requested comparisons are invalid.
+	 *
+	 * @param array|Traversable $options Options to set.
+	 * @return self
+	 */
+	public function setOptions( $options = [] ) {
+		$next = $this->options;
+
+		foreach ( $options as $key => $value ) {
+			if ( \array_key_exists( $key, $next ) ) {
+				$next[ $key ] = $value;
+			}
+		}
+
+		try {
+			$this->valid_html = new ValidatorByOperator( $next['operator'], $next['content'] );
+		} catch ( \Exception $exception ) {
+			throw new InvalidArgumentException( 'Invalid clause for inner HTML: ' . $exception->getMessage() );
+		}
+
+		$options = array_merge( $options, $next );
+
+		return parent::setOptions( $options );
+	}
+
+	/**
+	 * Apply block validation logic and add any validation errors.
+	 *
+	 * @param WP_Block_Parser_Block $block The block to test.
+	 */
+	protected function test_block( WP_Block_Parser_Block $block ): void {
+		if ( ! $this->valid_html->isValid( $block->innerHTML ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$this->error( self::NO_MATCHING_INNERHTML );
+		}
+	}
+}

--- a/tests/alley/wp/test-match-blocks-with-innerhtml.php
+++ b/tests/alley/wp/test-match-blocks-with-innerhtml.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Class file for Test_Match_Blocks_With_InnerHTML
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-match-blocks
+ */
+
+namespace Alley\WP;
+
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests the `with_innerhtml` parameter to `match_blocks()`.
+ */
+final class Test_Match_Blocks_With_InnerHTML extends Test_Case {
+	/**
+	 * Example block HTML.
+	 *
+	 * @var string
+	 */
+	private const BLOCK = '<!-- wp:paragraph --><p>Lorem ipsum dolor</p><!-- wp:paragraph /-->';
+
+	/**
+	 * Match exact string in inner HTML.
+	 */
+	public function test_exact_with_innerhtml_match() {
+		$this->assertNotEmpty(
+			match_blocks(
+				static::BLOCK,
+				[
+					'with_innerhtml' => ' ipsum ',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Match strings in inner HTML case-insensitively.
+	 */
+	public function test_case_insensitive_with_innerhtml_match() {
+		$this->assertNotEmpty(
+			match_blocks(
+				static::BLOCK,
+				[
+					'with_innerhtml' => 'lorem',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Strings not in the HTML should return no matches.
+	 */
+	public function test_with_innerhtml_not_match() {
+		$this->assertEmpty(
+			match_blocks(
+				static::BLOCK,
+				[
+					'with_innerhtml' => 'sit amet',
+				]
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

- `with_innerhtml` parameter for matching blocks by their inner HTML.

### Changed

### Deprecated

### Removed

### Fixed

### Security
