### PR TITLE
Add 'has_innerblocks' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Added
 
 - `with_innerhtml` parameter for matching blocks by their inner HTML.
+- `has_innerblocks` parameter for matching blocks by whether they have inner blocks. Includes companion `\Alley\WP\Validator\Block_InnerBlocks_Count` validator.
 - `CONTAINS` and `NOT CONTAINS` (case-sensitive), and `LIKE` and `NOT LIKE` (case-insensitive) operators to `attrs` parameter.
 - Passing a single block instance will return matches within its inner blocks.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Blocks can be matched by:
 * Block inner HTML (`with_innerhtml`)
 * The block's positive or negative index within the set (`position`)
 * Whether the block represents only space (`skip_empty_blocks`)
+* Whether the block has inner blocks (`has_innerblocks`)
 
 Passing matching parameters is optional; all non-empty blocks match by default.
 
@@ -337,6 +338,32 @@ $blocks = \Alley\WP\match_blocks(
 );
 ```
 
+Get only blocks with inner blocks:
+
+```php
+<?php
+
+$blocks = \Alley\WP\match_blocks(
+    $post,
+    [
+        'has_innerblocks' => true,
+    ]
+);
+```
+
+Get only blocks without inner blocks:
+
+```php
+<?php
+
+$blocks = \Alley\WP\match_blocks(
+    $post,
+    [
+        'has_innerblocks' => false,
+    ]
+);
+```
+
 ## Validators
 
 This package provides classes for validating blocks based on the [Laminas Validator](https://docs.laminas.dev/laminas-validator/) framework and [Laminas Validator Extensions](https://github.com/alleyinteractive/laminas-validator-extensions) package, plus a custom base block validation class.
@@ -528,6 +555,59 @@ $valid = new Alley\WP\Validator\Block_Offset(
     ],
 );
 $valid->isValid( $blocks[2] ); // true
+```
+
+### `Block_InnerBlocks_Count`
+
+`Alley\WP\Validator\Block_InnerBlocks_Count` validates whether the number of inner blocks in the given block passes the specified comparison.
+
+The block passes validation if the comparison is true for the count of inner blocks. Inner blocks within inner blocks don't count towards the total.
+
+#### Supported options
+
+The following options are supported for `Alley\WP\Validator\Block_InnerBlocks_Count`:
+
+* `count`: The expected number of inner blocks for the comparison. Default `0`.
+* `operator`: The PHP comparison operator used to compare the input block's inner blocks and `count`.
+
+#### Basic usage
+
+```php
+<?php
+
+$blocks = parse_blocks(
+    <<<HTML
+<!-- wp:foo -->
+    <!-- wp:bar -->
+        <!-- wp:baz /-->
+    <!-- /wp:bar -->
+<!-- /wp:foo -->
+HTML
+);
+
+$valid = new \Alley\WP\Validator\Block_InnerBlocks_Count(
+    [
+        'count'    => 1,
+        'operator' => '===',
+    ]
+);
+$valid->isValid( $blocks[0] ); // true
+
+$valid = new \Alley\WP\Validator\Block_InnerBlocks_Count(
+    [
+        'count'    => 0,
+        'operator' => '>',
+    ]
+);
+$valid->isValid( $blocks[0] ); // true
+
+$valid = new \Alley\WP\Validator\Block_InnerBlocks_Count(
+    [
+        'count'    => 42,
+        'operator' => '<=',
+    ]
+);
+$valid->isValid( $blocks[0] ); // true
 ```
 
 ### `Nonempty_Block`

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ The block passes validation if the comparison is true for the count of inner blo
 
 The following options are supported for `Alley\WP\Validator\Block_InnerBlocks_Count`:
 
-* `count`: The expected number of inner blocks for the comparison. Default `0`.
+* `count`: The expected number of inner blocks for the comparison.
 * `operator`: The PHP comparison operator used to compare the input block's inner blocks and `count`.
 
 #### Basic usage

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -46,6 +46,7 @@
         <properties>
             <property name="customPropertiesWhitelist" type="array">
                 <element value="blockName"/>
+                <element value="innerBlocks"/>
                 <element value="innerHTML"/>
                 <element value="messageTemplates"/>
                 <element value="messageVariables"/>

--- a/src/alley/wp/match-blocks.php
+++ b/src/alley/wp/match-blocks.php
@@ -16,6 +16,7 @@ use Alley\Validator\FastFailValidatorChain;
 use Alley\WP\Validator\Block_InnerHTML;
 use Alley\WP\Validator\Block_Name;
 use Alley\WP\Validator\Block_Offset;
+use Alley\WP\Validator\Block_InnerBlocks_Count;
 use Alley\WP\Validator\Nonempty_Block;
 
 /**
@@ -46,6 +47,7 @@ use Alley\WP\Validator\Nonempty_Block;
  *        }
  *    }
  *    @type bool                      $count             Return the number of found blocks instead of the set.
+ *    @type bool                      $has_innerblocks   Return only blocks that have, or don't have, inner blocks.
  *    @type bool                      $flatten           Recursively descend into inner blocks, test each one against the
  *                                                       criteria, and count each towards totals. Default false.
  *    @type int                       $limit             Extract at most this many blocks. Default `-1`, or no limit.
@@ -74,6 +76,7 @@ function match_blocks( $source, $args = [] ) {
 			'attrs'             => [],
 			'count'             => false,
 			'flatten'           => false,
+			'has_innerblocks'   => null,
 			'limit'             => -1,
 			'name'              => '',
 			'nth_of_type'       => null,
@@ -175,6 +178,17 @@ function match_blocks( $source, $args = [] ) {
 					[
 						'content'  => $args['with_innerhtml'],
 						'operator' => 'LIKE',
+					],
+				),
+			);
+		}
+
+		if ( null !== $args['has_innerblocks'] ) {
+			$validator->attach(
+				new Block_InnerBlocks_Count(
+					[
+						'count'    => 0,
+						'operator' => $args['has_innerblocks'] ? '>' : '===',
 					],
 				),
 			);

--- a/src/alley/wp/validator/class-block-innerblocks-count.php
+++ b/src/alley/wp/validator/class-block-innerblocks-count.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Block_InnerBlocks_Count class file
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-match-blocks
+ */
+
+namespace Alley\WP\Validator;
+
+use Alley\Validator\AlwaysValid;
+use Alley\Validator\Comparison;
+use Alley\Validator\Not;
+use Alley\Validator\WithMessage;
+use Laminas\Validator\Exception\InvalidArgumentException;
+use Laminas\Validator\ValidatorInterface;
+use Traversable;
+use WP_Block;
+use WP_Block_Parser_Block;
+use WP_Error;
+
+/**
+ * Validates whether the given block has a number of inner blocks.
+ */
+final class Block_InnerBlocks_Count extends Block_Validator {
+	/**
+	 * Array of validation failure message templates.
+	 *
+	 * @var string[]
+	 */
+	protected $messageTemplates = [
+		'not_equal'                    => '',
+		'not_identical'                => '',
+		'is_equal'                     => '',
+		'is_identical'                 => '',
+		'not_less_than'                => '',
+		'not_greater_than'             => '',
+		'not_less_than_or_equal_to'    => '',
+		'not_greater_than_or_equal_to' => '',
+		'invalid_comparison'           => '',
+		'default'                      => '',
+	];
+
+	/**
+	 * Array of additional variables available for validation failure messages.
+	 *
+	 * @var string[]
+	 */
+	protected $messageVariables = [
+		'count' => [
+			'options' => 'count',
+		],
+	];
+
+	/**
+	 * Options for this validator.
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		'operator' => '>=',
+		'count'    => 0,
+	];
+
+	/**
+	 * Valid inner block counts based on options.
+	 *
+	 * @var ValidatorInterface
+	 */
+	private ValidatorInterface $valid_comparisons;
+
+	/**
+	 * Set up.
+	 *
+	 * @param array|Traversable $options Validator options.
+	 */
+	public function __construct( $options = null ) {
+		$this->localize_templates();
+
+		$this->valid_comparisons = new Comparison(
+			[
+				'operator' => $this->options['operator'],
+				'compared' => $this->options['count'],
+			],
+		);
+
+		parent::__construct( $options );
+	}
+
+	/**
+	 * Sets one or multiple options. Refreshes the cached validators for the comparisons.
+	 *
+	 * @throws InvalidArgumentException If requested comparisons are invalid.
+	 *
+	 * @param array|Traversable $options Options to set.
+	 * @return self
+	 */
+	public function setOptions( $options = [] ) {
+		parent::setOptions( $options );
+
+		try {
+			$this->valid_comparisons = new Comparison(
+				[
+					'operator' => $this->options['operator'],
+					'compared' => $this->options['count'],
+				],
+			);
+		} catch ( \Exception $exception ) {
+			$message = 'Invalid comparison options for count of inner blocks: ' . $exception->getMessage();
+
+			/*
+			 * Force all blocks to fail validation while the new options are invalid in relation to one another.
+			 * Don't try to undo the work of `parent::setOptions()`, since that might leave the validator in
+			 * an unpredictable state.
+			 */
+			$this->valid_comparisons = new WithMessage(
+				'invalidComparison',
+				$message,
+				new Not( new AlwaysValid(), $message ),
+			);
+
+			throw new InvalidArgumentException( $message );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Apply block validation logic and add any validation errors.
+	 *
+	 * @param WP_Block_Parser_Block $block The block to test.
+	 */
+	protected function test_block( WP_Block_Parser_Block $block ): void {
+		$count = \count( $block->innerBlocks );
+
+		if ( ! $this->valid_comparisons->isValid( $count ) ) {
+			$message_keys = array_keys( $this->valid_comparisons->getMessages() );
+
+			foreach ( $message_keys as $key ) {
+				$this->error( $this->message( $key ), $count );
+			}
+		}
+	}
+
+	/**
+	 * Sets the 'count' option.
+	 *
+	 * @param int $count Option.
+	 */
+	protected function setCount( $count ) {
+		$this->options['count'] = (int) $count;
+	}
+
+	/**
+	 * This validator relies on other validators to perform the final comparison of the inner block count.
+	 * Here, map failure message identifiers from those validators to the ones defined by this validator.
+	 *
+	 * @param string $origin Upstream validator failure message identifier.
+	 * @return string This validator's identifier.
+	 */
+	private function message( string $origin ): string {
+		switch ( $origin ) {
+			case 'notEqual':
+				return 'not_equal';
+			case 'notIdentical':
+				return 'not_identical';
+			case 'isEqual':
+				return 'is_equal';
+			case 'isIdentical':
+				return 'is_identical';
+			case 'notLessThan':
+				return 'not_less_than';
+			case 'notGreaterThan':
+				return 'not_greater_than';
+			case 'notLessThanOrEqualTo':
+				return 'not_less_than_or_equal_to';
+			case 'notGreaterThanOrEqualTo':
+				return 'not_greater_than_or_equal_to';
+			case 'invalidComparison':
+				return 'invalid_comparison';
+			default:
+				return 'default';
+		}
+	}
+
+	/**
+	 * Localize message templates.
+	 */
+	private function localize_templates(): void {
+		$neq = sprintf(
+			/* translators: 1: expected count placeholder, 2: actual count placeholder */
+			__( 'Number of inner blocks must be %1$s but is %2$s.', 'alley' ),
+			'%count%',
+			'%value%',
+		);
+
+		$ieq = sprintf(
+			/* translators: 1: expected count placeholder */
+			__( 'Number of inner blocks must not be %1$s.', 'alley' ),
+			'%count%',
+		);
+
+		$nlt = sprintf(
+			/* translators: 1: expected count placeholder, 2: actual count placeholder */
+			__( 'Number of inner blocks must be less than %1$s but is %2$s.', 'alley' ),
+			'%count%',
+			'%value%',
+		);
+
+		$ngt = sprintf(
+			/* translators: 1: expected count placeholder, 2: actual count placeholder */
+			__( 'Number of inner blocks must be greater than %1$s but is %2$s.', 'alley' ),
+			'%count%',
+			'%value%',
+		);
+
+		$nlte = sprintf(
+			/* translators: 1: expected count placeholder, 2: actual count placeholder */
+			__( 'Number of inner blocks must be less than or equal to %1$s but is %2$s.', 'alley' ),
+			'%count%',
+			'%value%',
+		);
+
+		$ngte = sprintf(
+			/* translators: 1: expected count placeholder, 2: actual count placeholder */
+			__( 'Number of inner blocks must be greater than or equal to %1$s but is %2$s.', 'alley' ),
+			'%count%',
+			'%value%',
+		);
+
+		$this->messageTemplates = [
+			'not_equal'                    => $neq,
+			'not_identical'                => $neq,
+			'is_equal'                     => $ieq,
+			'is_identical'                 => $ieq,
+			'not_less_than'                => $nlt,
+			'not_greater_than'             => $ngt,
+			'not_less_than_or_equal_to'    => $nlte,
+			'not_greater_than_or_equal_to' => $ngte,
+			'invalid_comparison'           => __( 'Invalid comparison options for count of inner blocks.', 'alley' ),
+			'default'                      => __( 'Invalid count of inner blocks.', 'alley' ),
+		];
+	}
+}

--- a/tests/alley/wp/test-match-blocks-has-innerblocks.php
+++ b/tests/alley/wp/test-match-blocks-has-innerblocks.php
@@ -57,17 +57,18 @@ final class Test_Match_Blocks_Has_InnerBlocks extends Test_Case {
 	}
 
 	/**
-	 * Blocks without inner blocks should be matched.
+	 * Only the block without inner blocks should be matched.
 	 */
 	public function test_has_no_innerblocks() {
-		$this->assertCount(
-			0,
-			match_blocks(
-				static::BLOCKS,
-				[
-					'has_innerblocks' => false,
-				]
-			)
+		$actual = match_blocks(
+			static::BLOCKS,
+			[
+				'flatten'         => true,
+				'has_innerblocks' => false,
+			]
 		);
+
+		$this->assertCount( 1, $actual );
+		$this->assertSame( 'core/baz', $actual[0]['blockName'] );
 	}
 }

--- a/tests/alley/wp/test-match-blocks-has-innerblocks.php
+++ b/tests/alley/wp/test-match-blocks-has-innerblocks.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Class file for Test_Match_Blocks_Has_InnerBlocks
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-match-blocks
+ */
+
+namespace Alley\WP;
+
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests the `has_innerblocks` parameter to `match_blocks()`.
+ */
+final class Test_Match_Blocks_Has_InnerBlocks extends Test_Case {
+	/**
+	 * Example block HTML.
+	 *
+	 * @var string
+	 */
+	private const BLOCKS = '<!-- wp:foo --><!-- wp:bar --><!-- wp:baz /--><!-- /wp:bar --><!-- /wp:foo -->';
+
+	/**
+	 * Blocks with inner blocks should be matched.
+	 */
+	public function test_has_innerblocks() {
+		$this->assertCount(
+			1,
+			match_blocks(
+				static::BLOCKS,
+				[
+					'has_innerblocks' => true,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Inner blocks with their own inner blocks should be matched.
+	 */
+	public function test_has_flattened_innerblocks() {
+		$this->assertCount(
+			2,
+			match_blocks(
+				static::BLOCKS,
+				[
+					'flatten'         => true,
+					'has_innerblocks' => true,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Blocks without inner blocks should be matched.
+	 */
+	public function test_has_no_innerblocks() {
+		$this->assertCount(
+			0,
+			match_blocks(
+				static::BLOCKS,
+				[
+					'has_innerblocks' => false,
+				]
+			)
+		);
+	}
+}

--- a/tests/alley/wp/validator/test-block-innerblocks-count.php
+++ b/tests/alley/wp/validator/test-block-innerblocks-count.php
@@ -237,6 +237,7 @@ final class Test_Block_InnerBlocks_Count extends Test_Case {
 			);
 		} catch ( \Exception $exception ) {
 			// Do nothing.
+			unset( $exception );
 		}
 
 		$this->assertFalse( $validator->isValid( $this->block() ) );

--- a/tests/alley/wp/validator/test-block-innerblocks-count.php
+++ b/tests/alley/wp/validator/test-block-innerblocks-count.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Class file for Test_Block_InnerBlocks_Count
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-match-blocks
+ */
+
+namespace Alley\WP\Validator;
+
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Unit tests for the inner blocks count validator.
+ */
+final class Test_Block_InnerBlocks_Count extends Test_Case {
+	/**
+	 * Test that valid input with the given options is marked as valid.
+	 *
+	 * @dataProvider data_valid_input
+	 *
+	 * @param mixed $input   Input.
+	 * @param array $options Options.
+	 */
+	public function test_valid_input( $input, $options ) {
+		$validator = new Block_InnerBlocks_Count( $options );
+		$this->assertTrue( $validator->isValid( $input ) );
+	}
+
+	/**
+	 * Data provider for testing valid input.
+	 *
+	 * @return array
+	 */
+	public function data_valid_input() {
+		$block = $this->block();
+
+		return [
+			[
+				$block,
+				[
+					'operator' => '==',
+					'count'    => 3,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '===',
+					'count'    => 3,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '!=',
+					'count'    => 42,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '<>',
+					'count'    => 42,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '!==',
+					'count'    => 42,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '<',
+					'count'    => 42,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '>',
+					'count'    => 0,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '<=',
+					'count'    => 3,
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '>=',
+					'count'    => 3,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test that invalid input with the given options is marked as invalid.
+	 *
+	 * @dataProvider data_invalid_input
+	 *
+	 * @param mixed $input    Input.
+	 * @param array $options  Options.
+	 * @param array $messages Expected error messages.
+	 */
+	public function test_invalid_input( $input, $options, $messages ) {
+		$validator = new Block_InnerBlocks_Count( $options );
+		$this->assertFalse( $validator->isValid( $input ) );
+		$this->assertSame( $messages, $validator->getMessages() );
+	}
+
+	/**
+	 * Data provider for testing invalid input.
+	 *
+	 * @return array
+	 */
+	public function data_invalid_input() {
+		$block = $this->block();
+
+		return [
+			[
+				$block,
+				[
+					'operator' => '==',
+					'count'    => 0,
+				],
+				[
+					'not_equal' => 'Number of inner blocks must be 0 but is 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '===',
+					'count'    => 0,
+				],
+				[
+					'not_identical' => 'Number of inner blocks must be 0 but is 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '!=',
+					'count'    => 3,
+				],
+				[
+					'is_equal' => 'Number of inner blocks must not be 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '<>',
+					'count'    => 3,
+				],
+				[
+					'is_equal' => 'Number of inner blocks must not be 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '!==',
+					'count'    => 3,
+				],
+				[
+					'is_identical' => 'Number of inner blocks must not be 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '<',
+					'count'    => 0,
+				],
+				[
+					'not_less_than' => 'Number of inner blocks must be less than 0 but is 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '>',
+					'count'    => 42,
+				],
+				[
+					'not_greater_than' => 'Number of inner blocks must be greater than 42 but is 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '<=',
+					'count'    => 0,
+				],
+				[
+					'not_less_than_or_equal_to' => 'Number of inner blocks must be less than or equal to 0 but is 3.',
+				],
+			],
+			[
+				$block,
+				[
+					'operator' => '>=',
+					'count'    => 42,
+				],
+				[
+					'not_greater_than_or_equal_to' => 'Number of inner blocks must be greater than or equal to 42 but is 3.',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Invalid combinations of comparison options should throw an exception and not validate anything.
+	 */
+	public function test_invalid_options() {
+		$validator = new Block_InnerBlocks_Count();
+
+		try {
+			$validator->setOptions(
+				[
+					'operator' => 'foo',
+				],
+			);
+		} catch ( \Exception $exception ) {
+			// Do nothing.
+		}
+
+		$this->assertFalse( $validator->isValid( $this->block() ) );
+
+		$messages = $validator->getMessages();
+
+		$this->assertSame(
+			'Invalid comparison options for count of inner blocks.',
+			current( $messages ),
+		);
+	}
+
+	/**
+	 * Test block.
+	 *
+	 * @return array
+	 */
+	protected function block() {
+		$blocks = parse_blocks(
+			<<<HTML
+<!-- wp:columns -->
+<div class="wp-block-columns">
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>This is a column block. It has <strong>3</strong> columns.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Paragraph 2 is in the middle.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Paragraph 3 is in the last column.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+HTML
+		);
+
+		return $blocks[0];
+	}
+}


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

- `has_innerblocks` parameter for matching blocks by whether they have inner blocks. Includes companion `\Alley\WP\Validator\Block_InnerBlocks_Count` validator.

### Changed

### Deprecated

### Removed

### Fixed

### Security
