### PR TITLE
Drop PHP 7.4 support; update Alley domain; mark version 2.0.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 7.4 ]
+        php: [ 8.0 ]
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.0, 7.4 ]
+        php: [ 8.2, 8.1, 8.0 ]
         wp_version: [ "latest" ]
         can_fail: [ false ]
         multisite: [ 0,1 ]

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 /**
  * PHP-CS-Fixer configuration
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 - Passing a single block instance will return matches within its inner blocks.
 
+### Removed
+
+- PHP 7.4 support.
+
 ## 1.0.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.0.0
+
 ### Added
 
 - `with_innerhtml` parameter for matching blocks by their inner HTML. Includes companion `\Alley\WP\Validator\Block_InnerHTML` validator.

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
   },
   "require": {
     "php": "^8.0",
-    "alleyinteractive/laminas-validator-extensions": "dev-main"
+    "alleyinteractive/laminas-validator-extensions": "^2.0.0"
   },
   "require-dev": {
-    "alleyinteractive/alley-coding-standards": "^0.3",
+    "alleyinteractive/alley-coding-standards": "^1.0.0",
     "friendsofphp/php-cs-fixer": "^3.8",
-    "mantle-framework/testkit": "^0.5"
+    "mantle-framework/testkit": "^0.9"
   },
   "scripts": {
     "fixer": "php-cs-fixer -v fix --allow-risky=yes",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "lock": false
   },
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.0",
     "alleyinteractive/laminas-validator-extensions": "dev-main"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Alley",
-      "email": "info@alley.co"
+      "email": "info@alley.com"
     }
   ],
   "autoload": {

--- a/src/alley/wp/internals/internals.php
+++ b/src/alley/wp/internals/internals.php
@@ -2,7 +2,7 @@
 /**
  * Internal functions. These functions are not subject to semantic-versioning constraints
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/match-blocks.php
+++ b/src/alley/wp/match-blocks.php
@@ -2,7 +2,7 @@
 /**
  * `match_blocks()` functions
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-block-attribute.php
+++ b/src/alley/wp/validator/class-block-attribute.php
@@ -2,7 +2,7 @@
 /**
  * Block_Attribute class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-block-innerblocks-count.php
+++ b/src/alley/wp/validator/class-block-innerblocks-count.php
@@ -2,7 +2,7 @@
 /**
  * Block_InnerBlocks_Count class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-block-innerhtml.php
+++ b/src/alley/wp/validator/class-block-innerhtml.php
@@ -2,7 +2,7 @@
 /**
  * Block_InnerHTML class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-block-name.php
+++ b/src/alley/wp/validator/class-block-name.php
@@ -2,7 +2,7 @@
 /**
  * Block_Name class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-block-offset.php
+++ b/src/alley/wp/validator/class-block-offset.php
@@ -2,7 +2,7 @@
 /**
  * Block_Offset class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-block-validator.php
+++ b/src/alley/wp/validator/class-block-validator.php
@@ -12,7 +12,7 @@
 
 namespace Alley\WP\Validator;
 
-use Alley\Validator\BaseValidator;
+use Alley\Validator\ExtendedAbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use WP_Block;
 use WP_Block_Parser_Block;
@@ -20,7 +20,7 @@ use WP_Block_Parser_Block;
 /**
  * Abstract class for validating WordPress blocks.
  */
-abstract class Block_Validator extends BaseValidator {
+abstract class Block_Validator extends ExtendedAbstractValidator {
 	/**
 	 * Properties that need to be in the submitted block to convert it into a parsed block.
 	 *

--- a/src/alley/wp/validator/class-block-validator.php
+++ b/src/alley/wp/validator/class-block-validator.php
@@ -2,7 +2,7 @@
 /**
  * Block_Validator class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/validator/class-nonempty-block.php
+++ b/src/alley/wp/validator/class-nonempty-block.php
@@ -2,7 +2,7 @@
 /**
  * Nonempty_Block class file
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/internals/test-match-blocks-internals.php
+++ b/tests/alley/wp/internals/test-match-blocks-internals.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Internals
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-block.php
+++ b/tests/alley/wp/test-match-block.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Block
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-attrs.php
+++ b/tests/alley/wp/test-match-blocks-attrs.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Attrs
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-count.php
+++ b/tests/alley/wp/test-match-blocks-count.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-flatten.php
+++ b/tests/alley/wp/test-match-blocks-flatten.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Flatten
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-has-innerblocks.php
+++ b/tests/alley/wp/test-match-blocks-has-innerblocks.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Has_InnerBlocks
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-is-valid.php
+++ b/tests/alley/wp/test-match-blocks-is-valid.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Is_Valid
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-limit.php
+++ b/tests/alley/wp/test-match-blocks-limit.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Limit
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-name.php
+++ b/tests/alley/wp/test-match-blocks-name.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Name
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-nth-of-type.php
+++ b/tests/alley/wp/test-match-blocks-nth-of-type.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Nth_Of_Type
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-parameters.php
+++ b/tests/alley/wp/test-match-blocks-parameters.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Parameters
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-position.php
+++ b/tests/alley/wp/test-match-blocks-position.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Position
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-skip-empty-blocks.php
+++ b/tests/alley/wp/test-match-blocks-skip-empty-blocks.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Skip_Empty_Blocks
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-source.php
+++ b/tests/alley/wp/test-match-blocks-source.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_Source
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-with-attrs.php
+++ b/tests/alley/wp/test-match-blocks-with-attrs.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_With_Attrs
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-match-blocks-with-innerhtml.php
+++ b/tests/alley/wp/test-match-blocks-with-innerhtml.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Match_Blocks_With_InnerHTML
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/validator/test-block-attribute.php
+++ b/tests/alley/wp/validator/test-block-attribute.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Block_Attribute
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/validator/test-block-innerblocks-count.php
+++ b/tests/alley/wp/validator/test-block-innerblocks-count.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Block_InnerBlocks_Count
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/validator/test-block-name.php
+++ b/tests/alley/wp/validator/test-block-name.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Block_Name
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/validator/test-block-offset.php
+++ b/tests/alley/wp/validator/test-block-offset.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Block_Offset
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/validator/test-nonempty-block.php
+++ b/tests/alley/wp/validator/test-nonempty-block.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Nonempty_Block
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

- PHP 7.4 support.

### Fixed

### Security
