### PR TITLE
Require Composer WordPress autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 Nothing yet.
 
+## 2.0.1
+
+### Fixed
+
+- Missing `alleyinteractive/composer-wordpress-autoloader` dependency.
+
 ## 2.0.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   },
   "require": {
     "php": "^8.0",
+    "alleyinteractive/composer-wordpress-autoloader": "^1.0.0",
     "alleyinteractive/laminas-validator-extensions": "^2.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Missing `alleyinteractive/composer-wordpress-autoloader` dependency.

### Security
