### PR TITLE
Match 'classic' blocks as non-empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 Nothing yet.
 
+## 3.0.0
+
+### Changed
+
+* "Classic" blocks, which have inner HTML but no block name, are no longer considered empty.
+
 ## 2.0.1
 
 ### Fixed

--- a/src/alley/wp/validator/class-nonempty-block.php
+++ b/src/alley/wp/validator/class-nonempty-block.php
@@ -12,6 +12,8 @@
 
 namespace Alley\WP\Validator;
 
+use Alley\Validator\AnyValidator;
+use Alley\Validator\Not;
 use Laminas\Validator\ValidatorInterface;
 use Traversable;
 use WP_Block_Parser_Block;
@@ -37,11 +39,11 @@ final class Nonempty_Block extends Block_Validator {
 	];
 
 	/**
-	 * Validates the input block name.
+	 * Validates the input block.
 	 *
 	 * @var ValidatorInterface
 	 */
-	private ValidatorInterface $name_validator;
+	private ValidatorInterface $nonempty_tests;
 
 	/**
 	 * Set up.
@@ -51,9 +53,22 @@ final class Nonempty_Block extends Block_Validator {
 	public function __construct( $options = null ) {
 		$this->messageTemplates[ self::EMPTY_BLOCK ] = __( 'Block is empty.', 'alley' );
 
-		$this->name_validator = new Block_Name(
+		$this->nonempty_tests = new AnyValidator(
 			[
-				'name' => null,
+				new Not(
+					new Block_Name(
+						[
+							'name' => null,
+						],
+					),
+					__( 'Block name is null.', 'alley' ),
+				),
+				new Block_InnerHTML(
+					[
+						'operator' => 'REGEX',
+						'content'  => '#\S#',
+					],
+				),
 			],
 		);
 
@@ -66,7 +81,7 @@ final class Nonempty_Block extends Block_Validator {
 	 * @param WP_Block_Parser_Block $block The block to test.
 	 */
 	protected function test_block( WP_Block_Parser_Block $block ): void {
-		if ( $this->name_validator->isValid( $block ) ) {
+		if ( ! $this->nonempty_tests->isValid( $block ) ) {
 			$this->error( self::EMPTY_BLOCK );
 		}
 	}

--- a/tests/alley/wp/test-match-blocks-count.php
+++ b/tests/alley/wp/test-match-blocks-count.php
@@ -31,7 +31,30 @@ final class Test_Match_Blocks_Count extends Test_Case {
 			\count( $blocks ),
 			match_blocks(
 				implode( '', $blocks ),
-				[ 'count' => true ]
+				[
+					'count' => true,
+				],
+			)
+		);
+	}
+
+	/**
+	 * `count` should be non-zero when there are classic blocks.
+	 */
+	public function test_classic_blocks_count() {
+		$blocks = [
+			'<!-- wp:foo /-->',
+			'bar',
+			'<!-- wp:baz /-->',
+		];
+
+		$this->assertSame(
+			\count( $blocks ),
+			match_blocks(
+				implode( '', $blocks ),
+				[
+					'count' => true,
+				],
 			)
 		);
 	}
@@ -43,8 +66,10 @@ final class Test_Match_Blocks_Count extends Test_Case {
 		$this->assertSame(
 			0,
 			match_blocks(
-				'lorem ipsum dolor',
-				[ 'count' => true ]
+				"\n\n",
+				[
+					'count' => true,
+				],
 			)
 		);
 	}

--- a/tests/alley/wp/validator/test-nonempty-block.php
+++ b/tests/alley/wp/validator/test-nonempty-block.php
@@ -29,6 +29,16 @@ final class Test_Nonempty_Block extends Test_Case {
 	}
 
 	/**
+	 * Test that "Classic" blocks are not considered empty.
+	 */
+	public function test_classic_block() {
+		$blocks    = parse_blocks( '<p>Hello, world!</p>' );
+		$validator = new Nonempty_Block();
+
+		$this->assertTrue( $validator->isValid( $blocks[0] ) );
+	}
+
+	/**
 	 * Test that invalid input is marked as invalid.
 	 */
 	public function test_invalid_input() {


### PR DESCRIPTION
## Summary

Blocks named `null` have been considered "empty," but "classic" blocks containing freeform HTML are also named `null`. This behavior is unexpected during content migrations involving non-block content, since the default behavior of `match_blocks()` on such content can return an empty set, leading to data loss.

With this change in this PR, blocks are considered empty if they are named `null` and contain only space in their inner HTML. This change has the potential to cause a different kind of confusion: Given a piece of HTML without any block delimiters, the default behavior of `match_blocks()` will now be to return a set of one block instead of an empty set. 

I've chosen to proceed with the change despite this unintuitive result because the behavior of `match_blocks()` has tended to act as a reducer of the results returned by `WP_Block_Parser`, which also returns one block for the same HTML rather than eliminating the content from the parsed result.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

* "Classic" blocks, which have inner HTML but no block name, are no longer considered empty.

### Deprecated

### Removed

### Fixed

### Security
